### PR TITLE
Add extended euclidean algorithm

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,3 +1,2 @@
 - ignore: {name: Reduce duplication, within: Data.Poly.Internal.Dense.plusPoly}
 - ignore: {name: Reduce duplication, within: Data.Poly.Internal.Dense.karatsuba}
-- ignore: {name: Unused LANGUAGE pragma, within: Data.Poly.Internal.PolyOverFractional}

--- a/.travis.yml
+++ b/.travis.yml
@@ -133,6 +133,8 @@ script:
   - if [ $HCNUMVER -eq 80605 ] ; then ${CABAL} new-build -w ${HC} ${TEST} ${BENCH} --constraint='semirings == 0.3.1.2' all ; fi
   # Constraint set semirings-0.4.1
   - if [ $HCNUMVER -eq 80605 ] ; then ${CABAL} new-build -w ${HC} ${TEST} ${BENCH} --constraint='semirings == 0.4.1' all ; fi
+  # Constraint set semirings-0.5
+  - if [ $HCNUMVER -eq 80605 ] ; then ${CABAL} new-build -w ${HC} ${TEST} ${BENCH} --constraint='semirings == 0.5' all ; fi
 
   # Constraint set quickcheck-classes-0.5.0.0
   - if [ $HCNUMVER -eq 80605 ] ; then ${CABAL} new-build -w ${HC} ${TEST} ${BENCH} --constraint='quickcheck-classes == 0.5.0.0' all ; fi

--- a/bench/SparseBench.hs
+++ b/bench/SparseBench.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP        #-}
 {-# LANGUAGE RankNTypes #-}
 
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
@@ -18,9 +17,6 @@ benchSuite = bgroup "sparse" $ concat
   , map benchEval     $ zip tabs vecs2
   , map benchDeriv    $ zip tabs vecs2
   , map benchIntegral $ zip tabs vecs2'
-#if MIN_VERSION_semirings(0,4,2)
-  , map benchGcdExt   $ take 2 $ zip3 tabs vecs2' vecs3'
-#endif
   ]
 
 tabs :: [Int]
@@ -38,10 +34,6 @@ vecs3 :: [UPoly Int]
 vecs3 = flip map tabs $
   \n -> toPoly $ U.generate n (\i -> (fromIntegral i ^ 3, i * 3))
 
-vecs3' :: [UPoly Double]
-vecs3' = flip map (repeat 2) $
-  \n -> toPoly $ U.generate n (\i -> (fromIntegral i ^ 3, fromIntegral i * 3))
-
 benchAdd :: (Int, UPoly Int, UPoly Int) -> Benchmark
 benchAdd (k, xs, ys) = bench ("add/" ++ show k) $ nf (doBinOp (+) xs) ys
 
@@ -56,13 +48,6 @@ benchDeriv (k, xs) = bench ("deriv/" ++ show k) $ nf doDeriv xs
 
 benchIntegral :: (Int, UPoly Double) -> Benchmark
 benchIntegral (k, xs) = bench ("integral/" ++ show k) $ nf doIntegral xs
-
-#if MIN_VERSION_semirings(0,4,2)
-
-benchGcdExt :: (Int, UPoly Double, UPoly Double) -> Benchmark
-benchGcdExt (k, xs, ys) = bench ("gcdExt/" ++ show k) $ nf (doGcdExt xs) ys
-
-#endif
 
 doBinOp :: (forall a. Num a => a -> a -> a) -> UPoly Int -> UPoly Int -> Int
 doBinOp op xs ys = U.foldl' (\acc (_, x) -> acc + x) 0 zs
@@ -82,13 +67,3 @@ doIntegral :: UPoly Double -> Double
 doIntegral xs = U.foldl' (\acc (_, x) -> acc + x) 0 zs
   where
     zs = unPoly $ integral xs
-
-#if MIN_VERSION_semirings(0,4,2)
-
-doGcdExt :: UPoly Double -> UPoly Double -> Double
-doGcdExt xs ys = U.foldl' (\acc (_, x) -> acc + x) 0 zs
-  where
-    zs = unPoly $ fst $ gcdExt xs ys
-{-# INLINE doGcdExt #-}
-
-#endif

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -13,6 +13,11 @@ constraint-set semirings-0.4.1
   constraints:
     semirings == 0.4.1
 
+constraint-set semirings-0.5
+  ghc: ==8.6.5
+  constraints:
+    semirings == 0.5
+
 constraint-set quickcheck-classes-0.5.0.0
   ghc: ==8.6.5
   constraints:

--- a/src/Data/Poly/Internal/Dense/Fractional.hs
+++ b/src/Data/Poly/Internal/Dense/Fractional.hs
@@ -131,9 +131,9 @@ gcdM xs ys = do
 {-# INLINE gcdM #-}
 
 -- | Execute the extended Euclidean algorithm.
--- For polynomials 'a' and 'b', compute their unique greatest common divisor 'g'
--- and the unique coefficient polynomial 's' satisfying 'a''s' + 'b''t' = 'g',
--- such that either 'g' is monic, or 'g = 0' and 's' is monic, or 'g = s = 0'.
+-- For polynomials @a@ and @b@, compute their unique greatest common divisor @g@
+-- and the unique coefficient polynomial @s@ satisfying @as + bt = g@,
+-- such that either @g@ is monic, or @g = 0@ and @s@ is monic, or @g = s = 0@.
 --
 -- >>> gcdExt (X^2 + 1 :: UPoly Double) (X^3 + 3 * X :: UPoly Double)
 -- (1.0, 0.5 * X^2 + (-0.0) * X + 1.0)

--- a/src/Data/Poly/Internal/Dense/Fractional.hs
+++ b/src/Data/Poly/Internal/Dense/Fractional.hs
@@ -7,6 +7,7 @@
 -- GcdDomain for Fractional underlying
 --
 
+{-# LANGUAGE ConstraintKinds            #-}
 {-# LANGUAGE CPP                        #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE PatternSynonyms            #-}
@@ -35,7 +36,11 @@ import qualified Data.Vector.Generic.Mutable as MG
 import Data.Poly.Internal.Dense
 import Data.Poly.Internal.Dense.GcdDomain ()
 
-instance (Eq a, Eq (v a), Ring a, GcdDomain a, Fractional a, G.Vector v a) => Euclidean (Poly v a) where
+#if !MIN_VERSION_semirings(0,5,0)
+type Field a = (Fractional a, GcdDomain a, Ring a)
+#endif
+
+instance (Eq a, Eq (v a), Field a, G.Vector v a) => Euclidean (Poly v a) where
   degree (Poly xs) = fromIntegral (G.length xs)
 
   quotRem (Poly xs) (Poly ys) = (toPoly qs, toPoly rs)
@@ -140,7 +145,7 @@ gcdM xs ys = do
 -- >>> gcdExt (X^3 + 3 * X :: UPoly Double) (3 * X^4 + 3 * X^2 :: UPoly Double)
 -- (1.0 * X + 0.0,(-0.16666666666666666) * X^2 + (-0.0) * X + 0.3333333333333333)
 gcdExt
-  :: (Eq a, Fractional a, GcdDomain a, Ring a, G.Vector v a, Eq (v a))
+  :: (Eq a, Field a, G.Vector v a, Eq (v a))
   => Poly v a
   -> Poly v a
   -> (Poly v a, Poly v a)
@@ -166,7 +171,7 @@ gcdExt xs ys = case scaleMonic gs of
 -- >>> scaleMonic (3 * X^4 + 3 * X^2 :: UPoly Double)
 -- Just (0.3333333333333333, 1.0 * X^4 + 0.0 * X^3 + 1.0 * X^2 + 0.0 * X + 0.0)
 scaleMonic
-  :: (Eq a, Fractional a, GcdDomain a, Ring a, G.Vector v a, Eq (v a))
+  :: (Eq a, Field a, G.Vector v a, Eq (v a))
   => Poly v a
   -> Maybe (a, Poly v a)
 scaleMonic xs = case leading xs of

--- a/src/Data/Poly/Internal/Dense/Fractional.hs
+++ b/src/Data/Poly/Internal/Dense/Fractional.hs
@@ -29,7 +29,9 @@ import Control.Monad
 import Control.Monad.Primitive
 import Control.Monad.ST
 import Data.Euclidean
+#if !MIN_VERSION_semirings(0,5,0)
 import Data.Semiring (Ring)
+#endif
 import qualified Data.Vector.Generic as G
 import qualified Data.Vector.Generic.Mutable as MG
 
@@ -37,10 +39,10 @@ import Data.Poly.Internal.Dense
 import Data.Poly.Internal.Dense.GcdDomain ()
 
 #if !MIN_VERSION_semirings(0,5,0)
-type Field a = (Fractional a, GcdDomain a, Ring a)
+type Field a = (Euclidean a, Ring a)
 #endif
 
-instance (Eq a, Eq (v a), Field a, G.Vector v a) => Euclidean (Poly v a) where
+instance (Eq a, Eq (v a), Field a, Fractional a, Fractional a, G.Vector v a) => Euclidean (Poly v a) where
   degree (Poly xs) = fromIntegral (G.length xs)
 
   quotRem (Poly xs) (Poly ys) = (toPoly qs, toPoly rs)
@@ -145,7 +147,7 @@ gcdM xs ys = do
 -- >>> gcdExt (X^3 + 3 * X :: UPoly Double) (3 * X^4 + 3 * X^2 :: UPoly Double)
 -- (1.0 * X + 0.0,(-0.16666666666666666) * X^2 + (-0.0) * X + 0.3333333333333333)
 gcdExt
-  :: (Eq a, Field a, G.Vector v a, Eq (v a))
+  :: (Eq a, Field a, Fractional a, G.Vector v a, Eq (v a))
   => Poly v a
   -> Poly v a
   -> (Poly v a, Poly v a)
@@ -171,7 +173,7 @@ gcdExt xs ys = case scaleMonic gs of
 -- >>> scaleMonic (3 * X^4 + 3 * X^2 :: UPoly Double)
 -- Just (0.3333333333333333, 1.0 * X^4 + 0.0 * X^3 + 1.0 * X^2 + 0.0 * X + 0.0)
 scaleMonic
-  :: (Eq a, Field a, G.Vector v a, Eq (v a))
+  :: (Eq a, Field a, Fractional a, G.Vector v a, Eq (v a))
   => Poly v a
   -> Maybe (a, Poly v a)
 scaleMonic xs = case leading xs of

--- a/src/Data/Poly/Internal/PolyOverFractional.hs
+++ b/src/Data/Poly/Internal/PolyOverFractional.hs
@@ -10,7 +10,6 @@
 {-# LANGUAGE CPP                        #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE UndecidableInstances       #-}
 
 #if MIN_VERSION_semirings(0,4,2)
 

--- a/src/Data/Poly/Internal/PolyOverFractional.hs
+++ b/src/Data/Poly/Internal/PolyOverFractional.hs
@@ -8,6 +8,7 @@
 --
 
 {-# LANGUAGE CPP                        #-}
+{-# LANGUAGE ConstraintKinds            #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
@@ -32,11 +33,15 @@ import qualified Data.Poly.Internal.Dense.Fractional as Dense (fractionalGcd)
 newtype PolyOverFractional poly = PolyOverFractional { unPolyOverFractional :: poly }
   deriving (Eq, NFData, Num, Ord, Ring, Semiring, Show)
 
-instance (Eq a, Eq (v a), Ring a, GcdDomain a, Fractional a, G.Vector v a) => GcdDomain (PolyOverFractional (Dense.Poly v a)) where
+#if !MIN_VERSION_semirings(0,5,0)
+type Field a = (Fractional a, GcdDomain a, Ring a)
+#endif
+
+instance (Eq a, Eq (v a), Field a, G.Vector v a) => GcdDomain (PolyOverFractional (Dense.Poly v a)) where
   gcd (PolyOverFractional x) (PolyOverFractional y) = PolyOverFractional (Dense.fractionalGcd x y)
   {-# INLINE gcd #-}
 
-instance (Eq a, Eq (v a), Ring a, GcdDomain a, Fractional a, G.Vector v a) => Euclidean (PolyOverFractional (Dense.Poly v a)) where
+instance (Eq a, Eq (v a), Field a, G.Vector v a) => Euclidean (PolyOverFractional (Dense.Poly v a)) where
   degree (PolyOverFractional x) =
     degree x
   quotRem (PolyOverFractional x) (PolyOverFractional y) =

--- a/src/Data/Poly/Internal/PolyOverFractional.hs
+++ b/src/Data/Poly/Internal/PolyOverFractional.hs
@@ -34,14 +34,14 @@ newtype PolyOverFractional poly = PolyOverFractional { unPolyOverFractional :: p
   deriving (Eq, NFData, Num, Ord, Ring, Semiring, Show)
 
 #if !MIN_VERSION_semirings(0,5,0)
-type Field a = (Fractional a, GcdDomain a, Ring a)
+type Field a = (Euclidean a, Ring a)
 #endif
 
-instance (Eq a, Eq (v a), Field a, G.Vector v a) => GcdDomain (PolyOverFractional (Dense.Poly v a)) where
+instance (Eq a, Eq (v a), Field a, Fractional a, G.Vector v a) => GcdDomain (PolyOverFractional (Dense.Poly v a)) where
   gcd (PolyOverFractional x) (PolyOverFractional y) = PolyOverFractional (Dense.fractionalGcd x y)
   {-# INLINE gcd #-}
 
-instance (Eq a, Eq (v a), Field a, G.Vector v a) => Euclidean (PolyOverFractional (Dense.Poly v a)) where
+instance (Eq a, Eq (v a), Field a, Fractional a, G.Vector v a) => Euclidean (PolyOverFractional (Dense.Poly v a)) where
   degree (PolyOverFractional x) =
     degree x
   quotRem (PolyOverFractional x) (PolyOverFractional y) =

--- a/src/Data/Poly/Internal/Sparse/Fractional.hs
+++ b/src/Data/Poly/Internal/Sparse/Fractional.hs
@@ -60,9 +60,9 @@ quotientRemainder ts ys = case leading ys of
             xs' = xs - zs * ys
 
 -- | Execute the extended Euclidean algorithm.
--- For polynomials 'a' and 'b', compute their unique greatest common divisor 'g'
--- and the unique coefficient polynomial 's' satisfying 'a''s' + 'b''t' = 'g',
--- such that either 'g' is monic, or 'g = 0' and 's' is monic, or 'g = s = 0'.
+-- For polynomials @a@ and @b@, compute their unique greatest common divisor @g@
+-- and the unique coefficient polynomial @s@ satisfying @as + bt = g@,
+-- such that either @g@ is monic, or @g = 0@ and @s@ is monic, or @g = s = 0@.
 --
 -- >>> gcdExt (X^2 + 1 :: UPoly Double) (X^3 + 3 * X :: UPoly Double)
 -- (1.0, 0.5 * X^2 + (-0.0) * X + 1.0)

--- a/src/Data/Poly/Internal/Sparse/Fractional.hs
+++ b/src/Data/Poly/Internal/Sparse/Fractional.hs
@@ -28,17 +28,19 @@ import Prelude hiding (quotRem, quot, rem, gcd)
 import Control.Arrow
 import Control.Exception
 import Data.Euclidean
+#if !MIN_VERSION_semirings(0,5,0)
 import Data.Semiring (Ring)
+#endif
 import qualified Data.Vector.Generic as G
 
 import Data.Poly.Internal.Sparse
 import Data.Poly.Internal.Sparse.GcdDomain ()
 
 #if !MIN_VERSION_semirings(0,5,0)
-type Field a = (Fractional a, GcdDomain a, Ring a)
+type Field a = (Euclidean a, Ring a)
 #endif
 
-instance (Eq a, Eq (v (Word, a)), Field a, G.Vector v (Word, a)) => Euclidean (Poly v a) where
+instance (Eq a, Eq (v (Word, a)), Field a, Fractional a, G.Vector v (Word, a)) => Euclidean (Poly v a) where
   degree (Poly xs)
     | G.null xs = 0
     | otherwise = 1 + fromIntegral (fst (G.last xs))
@@ -74,7 +76,7 @@ quotientRemainder ts ys = case leading ys of
 -- >>> gcdExt (X^3 + 3 * X :: UPoly Double) (3 * X^4 + 3 * X^2 :: UPoly Double)
 -- (1.0 * X + 0.0,(-0.16666666666666666) * X^2 + (-0.0) * X + 0.3333333333333333)
 gcdExt
-  :: (Eq a, Field a, G.Vector v (Word, a), Eq (v (Word, a)))
+  :: (Eq a, Field a, Fractional a, G.Vector v (Word, a), Eq (v (Word, a)))
   => Poly v a
   -> Poly v a
   -> (Poly v a, Poly v a)
@@ -100,7 +102,7 @@ gcdExt xs ys = case scaleMonic gs of
 -- >>> scaleMonic (3 * X^4 + 3 * X^2 :: UPoly Double)
 -- Just (0.3333333333333333, 1.0 * X^4 + 0.0 * X^3 + 1.0 * X^2 + 0.0 * X + 0.0)
 scaleMonic
-  :: (Eq a, Field a, G.Vector v (Word, a), Eq (v (Word, a)))
+  :: (Eq a, Field a, Fractional a, G.Vector v (Word, a), Eq (v (Word, a)))
   => Poly v a
   -> Maybe (a, Poly v a)
 scaleMonic xs = case leading xs of

--- a/src/Data/Poly/Internal/Sparse/Fractional.hs
+++ b/src/Data/Poly/Internal/Sparse/Fractional.hs
@@ -7,6 +7,7 @@
 -- GcdDomain for Fractional underlying
 --
 
+{-# LANGUAGE ConstraintKinds            #-}
 {-# LANGUAGE CPP                        #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
@@ -33,7 +34,11 @@ import qualified Data.Vector.Generic as G
 import Data.Poly.Internal.Sparse
 import Data.Poly.Internal.Sparse.GcdDomain ()
 
-instance (Eq a, Eq (v (Word, a)), Ring a, GcdDomain a, Fractional a, G.Vector v (Word, a)) => Euclidean (Poly v a) where
+#if !MIN_VERSION_semirings(0,5,0)
+type Field a = (Fractional a, GcdDomain a, Ring a)
+#endif
+
+instance (Eq a, Eq (v (Word, a)), Field a, G.Vector v (Word, a)) => Euclidean (Poly v a) where
   degree (Poly xs)
     | G.null xs = 0
     | otherwise = 1 + fromIntegral (fst (G.last xs))
@@ -69,7 +74,7 @@ quotientRemainder ts ys = case leading ys of
 -- >>> gcdExt (X^3 + 3 * X :: UPoly Double) (3 * X^4 + 3 * X^2 :: UPoly Double)
 -- (1.0 * X + 0.0,(-0.16666666666666666) * X^2 + (-0.0) * X + 0.3333333333333333)
 gcdExt
-  :: (Eq a, Fractional a, GcdDomain a, Ring a, G.Vector v (Word, a), Eq (v (Word, a)))
+  :: (Eq a, Field a, G.Vector v (Word, a), Eq (v (Word, a)))
   => Poly v a
   -> Poly v a
   -> (Poly v a, Poly v a)
@@ -95,7 +100,7 @@ gcdExt xs ys = case scaleMonic gs of
 -- >>> scaleMonic (3 * X^4 + 3 * X^2 :: UPoly Double)
 -- Just (0.3333333333333333, 1.0 * X^4 + 0.0 * X^3 + 1.0 * X^2 + 0.0 * X + 0.0)
 scaleMonic
-  :: (Eq a, Fractional a, GcdDomain a, Ring a, G.Vector v (Word, a), Eq (v (Word, a)))
+  :: (Eq a, Field a, G.Vector v (Word, a), Eq (v (Word, a)))
   => Poly v a
   -> Maybe (a, Poly v a)
 scaleMonic xs = case leading xs of

--- a/src/Data/Poly/Sparse.hs
+++ b/src/Data/Poly/Sparse.hs
@@ -7,7 +7,8 @@
 -- Sparse polynomials with 'Num' instance.
 --
 
-{-# LANGUAGE PatternSynonyms     #-}
+{-# LANGUAGE CPP             #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 module Data.Poly.Sparse
   ( Poly
@@ -23,8 +24,12 @@ module Data.Poly.Sparse
   , eval
   , deriv
   , integral
+#if MIN_VERSION_semirings(0,4,2)
+  -- * Fractional coefficients
+  , gcdExt
+#endif
   ) where
 
 import Data.Poly.Internal.Sparse
-import Data.Poly.Internal.Sparse.Fractional ()
+import Data.Poly.Internal.Sparse.Fractional (gcdExt)
 import Data.Poly.Internal.Sparse.GcdDomain ()

--- a/src/Data/Poly/Sparse.hs
+++ b/src/Data/Poly/Sparse.hs
@@ -31,5 +31,7 @@ module Data.Poly.Sparse
   ) where
 
 import Data.Poly.Internal.Sparse
+#if MIN_VERSION_semirings(0,4,2)
 import Data.Poly.Internal.Sparse.Fractional (gcdExt)
 import Data.Poly.Internal.Sparse.GcdDomain ()
+#endif

--- a/src/Data/Poly/Sparse/Semiring.hs
+++ b/src/Data/Poly/Sparse/Semiring.hs
@@ -7,8 +7,9 @@
 -- Sparse polynomials with 'Semiring' instance.
 --
 
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE PatternSynonyms     #-}
+{-# LANGUAGE CPP              #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE PatternSynonyms  #-}
 
 module Data.Poly.Sparse.Semiring
   ( Poly
@@ -23,6 +24,10 @@ module Data.Poly.Sparse.Semiring
   , pattern X
   , eval
   , deriv
+#if MIN_VERSION_semirings(0,4,2)
+  -- * Fractional coefficients
+  , gcdExt
+#endif
   ) where
 
 import Data.Semiring (Semiring)
@@ -30,7 +35,7 @@ import qualified Data.Vector.Generic as G
 
 import Data.Poly.Internal.Sparse (Poly(..), VPoly, UPoly, leading)
 import qualified Data.Poly.Internal.Sparse as Sparse
-import Data.Poly.Internal.Sparse.Fractional ()
+import Data.Poly.Internal.Sparse.Fractional (gcdExt)
 import Data.Poly.Internal.Sparse.GcdDomain ()
 
 -- | Make 'Poly' from a list of (power, coefficient) pairs.

--- a/src/Data/Poly/Sparse/Semiring.hs
+++ b/src/Data/Poly/Sparse/Semiring.hs
@@ -35,8 +35,10 @@ import qualified Data.Vector.Generic as G
 
 import Data.Poly.Internal.Sparse (Poly(..), VPoly, UPoly, leading)
 import qualified Data.Poly.Internal.Sparse as Sparse
+#if MIN_VERSION_semirings(0,4,2)
 import Data.Poly.Internal.Sparse.Fractional (gcdExt)
 import Data.Poly.Internal.Sparse.GcdDomain ()
+#endif
 
 -- | Make 'Poly' from a list of (power, coefficient) pairs.
 -- (first element corresponds to a constant term).

--- a/test/Dense.hs
+++ b/test/Dense.hs
@@ -281,5 +281,4 @@ gcdExtTests = localOption (QuickCheckMaxSize 12) $ testGroup "gcdExt"
 sameUpToUnits :: (Eq a, GcdDomain a) => a -> a -> Bool
 sameUpToUnits x y = x == y ||
   isJust (x `divide` y) && isJust (y `divide` x)
-
 #endif

--- a/test/Sparse.hs
+++ b/test/Sparse.hs
@@ -11,13 +11,14 @@ module Sparse
   ( testSuite
   ) where
 
-import Prelude hiding (quotRem)
+import Prelude hiding (gcd, quotRem, rem)
 #if MIN_VERSION_semirings(0,4,2)
 import Data.Euclidean
 #endif
 import Data.Function
 import Data.Int
 import Data.List
+import Data.Maybe
 import Data.Poly.Sparse
 import qualified Data.Poly.Sparse.Semiring as S
 import Data.Proxy
@@ -57,6 +58,9 @@ testSuite = testGroup "Sparse"
     , lawsTests
     , evalTests
     , derivTests
+#if MIN_VERSION_semirings(0,4,2)
+    , gcdExtTests
+#endif
     ]
 
 lawsTests :: TestTree
@@ -264,3 +268,22 @@ derivTests = testGroup "deriv"
   --     deriv (eval (toPoly $ fmap (fmap $ monomial 0) $ unPoly p) q) ===
   --       deriv q * eval (toPoly $ fmap (fmap $ monomial 0) $ unPoly $ deriv p) q
   ]
+
+#if MIN_VERSION_semirings(0,4,2)
+gcdExtTests :: TestTree
+gcdExtTests = localOption (QuickCheckMaxSize 12) $ testGroup "gcdExt"
+  [ testProperty "gcdExt == S.gcdExt" $
+    \(a :: Poly V.Vector Rational) b ->
+      gcdExt a b === S.gcdExt a b
+  , testProperty "g == as (mod b) for gcdExt" $
+    \(a :: Poly V.Vector Rational) b -> b /= 0 ==>
+      uncurry ((. flip rem b) . (===) . flip rem b) ((* a) <$> gcdExt a b)
+  , testProperty "fst . gcdExt == gcd (mod units)" $
+    \(a :: Poly V.Vector Rational) b ->
+      fst (gcdExt a b) `sameUpToUnits` gcd a b
+  ]
+
+sameUpToUnits :: (Eq a, GcdDomain a) => a -> a -> Bool
+sameUpToUnits x y = x == y ||
+  isJust (x `divide` y) && isJust (y `divide` x)
+#endif


### PR DESCRIPTION
Added an extended Euclidean algorithm function `gcdExt` in `Data/Poly/Internal/Sparse/Fractional.hs` for `Num` and `Semiring` polynomials to continue addressing #22, as well as several simple tests and benchmarks. This mirrors the implementation in `Data/Poly/Internal/Dense/Fractional.hs` and as such is also unoptimised. The tests and benchmarks have shown that this is even slower than the dense `gcdExt`, but this makes sense.

As you said, GCD operations shouldn't be done with sparse polynomials, so wouldn't this be unnecessary as well? There could also be a convenient conversion function that switches between the dense and sparse flavours.