### PR TITLE
Improve doc comments for `pattern X` and `^-`

### DIFF
--- a/src/Data/Poly/Internal/Dense.hs
+++ b/src/Data/Poly/Internal/Dense.hs
@@ -455,7 +455,9 @@ integral' (Poly xs)
       lenXs = G.length xs
 {-# INLINABLE integral' #-}
 
--- | Create an identity polynomial.
+-- | The polynomial 'X'.
+--
+-- > X == monomial 1 1
 pattern X :: (Eq a, Num a, G.Vector v a) => Poly v a
 pattern X <- (isVar -> True)
   where X = var

--- a/src/Data/Poly/Internal/Dense/Laurent.hs
+++ b/src/Data/Poly/Internal/Dense/Laurent.hs
@@ -236,7 +236,9 @@ deriv (Laurent off (Poly xs)) =
   toLaurent (off - 1) $ Dense.toPoly' $ G.imap (times . Semiring.fromIntegral . (+ off)) xs
 {-# INLINE deriv #-}
 
--- | Create an identity polynomial.
+-- | The polynomial 'X'.
+--
+-- > X == monomial 1 one
 pattern X :: (Eq a, Semiring a, G.Vector v a) => Laurent v a
 pattern X <- (isVar -> True)
   where X = var
@@ -253,10 +255,14 @@ isVar (Laurent off (Poly xs))
   | otherwise          = off == 1 && G.length xs == 1 && G.unsafeHead xs == one
 {-# INLINE isVar #-}
 
--- | This operator can be applied only to monomials with unit coefficients,
--- but is instrumental to express Laurent polynomials
--- in mathematical fashion:
+-- | Used to construct monomials with negative powers.
 --
+-- This operator can be applied only to monomials with unit coefficients,
+-- but is instrumental to express Laurent polynomials
+-- in a mathematical fashion:
+--
+-- >>> X^-3 :: ULaurent Int
+-- 1 * X^-3
 -- >>> X + 2 + 3 * (X^2)^-1 :: ULaurent Int
 -- 1 * X + 2 + 0 * X^-1 + 3 * X^-2
 (^-)

--- a/src/Data/Poly/Internal/Multi/Laurent.hs
+++ b/src/Data/Poly/Internal/Multi/Laurent.hs
@@ -414,10 +414,14 @@ isVar i (MultiLaurent off (MultiPoly xs))
   && G.length xs == 1 && G.unsafeHead xs == (0, one)
 {-# INLINE isVar #-}
 
--- | This operator can be applied only to monomials with unit coefficients,
--- but is still instrumental to express Laurent polynomials
--- in mathematical fashion:
+-- | Used to construct monomials with negative powers.
 --
+-- This operator can be applied only to monomials with unit coefficients,
+-- but is instrumental to express Laurent polynomials
+-- in a mathematical fashion:
+--
+-- >>> X^-3 * Y^-1 :: UMultiLaurent 2 Int
+-- 1 * X^-3 * Y^-1
 -- >>> 3 * X^-1 + 2 * (Y^2)^-2 :: UMultiLaurent 2 Int
 -- 2 * Y^-4 + 3 * X^-1
 (^-)

--- a/src/Data/Poly/Semiring.hs
+++ b/src/Data/Poly/Semiring.hs
@@ -74,7 +74,9 @@ monomial = Dense.monomial'
 scale :: (Eq a, Semiring a, G.Vector v a) => Word -> a -> Poly v a -> Poly v a
 scale = Dense.scale'
 
--- | Create an identity polynomial.
+-- | The polynomial 'X'.
+--
+-- > X == monomial 1 one
 pattern X :: (Eq a, Semiring a, G.Vector v a) => Poly v a
 pattern X = Dense.X'
 

--- a/src/Data/Poly/Sparse.hs
+++ b/src/Data/Poly/Sparse.hs
@@ -74,7 +74,9 @@ scale
   -> Poly v a
 scale = Multi.scale . SU.singleton
 
--- | Create an identity polynomial.
+-- | The polynomial 'X'.
+--
+-- > X == monomial 1 1
 pattern X
   :: (Eq a, Num a, G.Vector v (SU.Vector 1 Word, a))
   => Poly v a

--- a/src/Data/Poly/Sparse/Laurent.hs
+++ b/src/Data/Poly/Sparse/Laurent.hs
@@ -58,15 +58,22 @@ scale
   -> Laurent v a
 scale = Multi.scale . SU.singleton
 
--- | Create an identity polynomial.
+-- | The polynomial 'X'.
+--
+-- > X == monomial 1 one
 pattern X
   :: (Eq a, Semiring a, G.Vector v (SU.Vector 1 Word, a))
   => Laurent v a
 pattern X = Multi.X
 
--- | This operator can be applied only to monomials with unit coefficients,
--- but is instrumental to express Laurent polynomials in mathematical fashion:
+-- | Used to construct monomials with negative powers.
 --
+-- This operator can be applied only to monomials with unit coefficients,
+-- but is instrumental to express Laurent polynomials
+-- in a mathematical fashion:
+--
+-- >>> X^-3 :: ULaurent Int
+-- 1 * X^-3
 -- >>> X + 2 + 3 * (X^2)^-1 :: ULaurent Int
 -- 1 * X + 2 + 3 * X^-2
 (^-)

--- a/src/Data/Poly/Sparse/Semiring.hs
+++ b/src/Data/Poly/Sparse/Semiring.hs
@@ -76,7 +76,9 @@ scale
   -> Poly v a
 scale = Multi.scale' . SU.singleton
 
--- | Create an identity polynomial.
+-- | The polynomial 'X'.
+--
+-- > X == monomial 1 one
 pattern X
   :: (Eq a, Semiring a, G.Vector v (SU.Vector 1 Word, a))
   => Poly v a


### PR DESCRIPTION
I think "polynomial 'X'" is clearer than "identity polynomial", since most (all?) people will be familiar with the notation, whereas I can't remember hearing about an "identity polynomial".

Btw, I noticed that there is no `Num`-based interface for Laurent polynomials, is there a specific reason for that?