### PR TITLE
Fix property tests & update CI

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20240708
+# version: 0.19.20250330
 #
-# REGENDATA ("0.19.20240708",["github","cabal.project"])
+# REGENDATA ("0.19.20250330",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:
@@ -28,19 +28,24 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.12.2
+            compilerKind: ghc
+            compilerVersion: 9.12.2
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.10.1
             compilerKind: ghc
             compilerVersion: 9.10.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.8.2
+          - compiler: ghc-9.8.4
             compilerKind: ghc
-            compilerVersion: 9.8.2
+            compilerVersion: 9.8.4
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.6
+          - compiler: ghc-9.6.7
             compilerKind: ghc
-            compilerVersion: 9.6.6
+            compilerVersion: 9.6.7
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.8
@@ -75,15 +80,29 @@ jobs:
             allow-failure: false
       fail-fast: false
     steps:
-      - name: apt
+      - name: apt-get install
         run: |
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+      - name: Install GHCup
+        run: |
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.30.0/x86_64-linux-ghcup-0.1.30.0 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.50.1/x86_64-linux-ghcup-0.1.50.1 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
+      - name: Install cabal-install
+        run: |
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.1.1-p1 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.1.1-p1 -vnormal+nowrap" >> "$GITHUB_ENV"
+      - name: Install GHC (GHCup)
+        if: matrix.setup-method == 'ghcup'
+        run: |
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.12.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -94,21 +113,12 @@ jobs:
           echo "LANG=C.UTF-8" >> "$GITHUB_ENV"
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
-          HCDIR=/opt/$HCKIND/$HCVER
-          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
-          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
-          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
-          echo "HC=$HC" >> "$GITHUB_ENV"
-          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
-          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.12.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
           echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
-          echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -239,8 +249,8 @@ jobs:
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
       - name: save cache
-        uses: actions/cache/save@v4
         if: always()
+        uses: actions/cache/save@v4
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store

--- a/poly.cabal
+++ b/poly.cabal
@@ -12,7 +12,7 @@ copyright: 2019-2020 Andrew Lelechenko
 category: Math, Numerical
 build-type: Simple
 cabal-version: 2.0
-tested-with: GHC ==8.6.5 GHC ==8.8.4 GHC ==8.10.7 GHC ==9.0.2 GHC ==9.2.8 GHC ==9.4.8 GHC ==9.6.6 GHC ==9.8.2 GHC ==9.10.1
+tested-with: GHC ==8.6.5 GHC ==8.8.4 GHC ==8.10.7 GHC ==9.0.2 GHC ==9.2.8 GHC ==9.4.8 GHC ==9.6.7 GHC ==9.8.4 GHC ==9.10.1 GHC ==9.12.2
 extra-source-files:
   changelog.md
   README.md
@@ -102,7 +102,7 @@ test-suite poly-tests
     base >=4.10 && <5,
     mod >=0.1.2,
     poly,
-    QuickCheck >=2.12 && <2.14.3,
+    QuickCheck >=2.12,
     quickcheck-classes-base,
     quickcheck-classes >=0.6.3,
     semirings >= 0.5.2,

--- a/test/DenseLaurent.hs
+++ b/test/DenseLaurent.hs
@@ -125,14 +125,14 @@ evalTests = testGroup "eval" $ concat
 
 evalTestGroup
   :: forall v a.
-     (Eq a, Field a, Arbitrary a, Show a, Eq (v a), Show (v a), G.Vector v a)
+     (Eq a, Field a, Num a, Arbitrary a, Show a, Eq (v a), Show (v a), G.Vector v a)
   => Proxy (Laurent v a)
   -> [TestTree]
 evalTestGroup _ =
   [ testProperty "eval (p + q) r = eval p r + eval q r" $
-    \(ShortPoly p) (ShortPoly q) r -> e (p `plus` q) r === e p r `plus` e q r
+    \(ShortPoly p) (ShortPoly q) (NonZero r) -> e (p `plus` q) r === e p r `plus` e q r
   , testProperty "eval (p * q) r = eval p r * eval q r" $
-    \(ShortPoly p) (ShortPoly q) r -> e (p `times` q) r === e p r `times` e q r
+    \(ShortPoly p) (ShortPoly q) (NonZero r) -> e (p `times` q) r === e p r `times` e q r
   , testProperty "eval x p = p" $
     \p -> e X p === p
   , testProperty "eval (monomial 0 c) p = c" $

--- a/test/MultiLaurent.hs
+++ b/test/MultiLaurent.hs
@@ -139,14 +139,14 @@ evalTests = testGroup "eval" $ concat
 
 evalTestGroup
   :: forall v a.
-     (Eq a, Field a, Arbitrary a, Show a, G.Vector v (Word, a), G.Vector v (SU.Vector 3 Word, a), G.Vector v (Data.Poly.Multi.Monom 3 a))
+     (Eq a, Field a, Num a, Arbitrary a, Show a, G.Vector v (Word, a), G.Vector v (SU.Vector 3 Word, a), G.Vector v (Data.Poly.Multi.Monom 3 a))
   => Proxy (MultiLaurent v 3 a)
   -> [TestTree]
 evalTestGroup _ =
   [ testProperty "eval (p + q) r = eval p r + eval q r" $
-    \(ShortPoly p) (ShortPoly q) r -> e (p `plus` q) r === e p r `plus` e q r
+    \(ShortPoly p) (ShortPoly q) r -> let r' = fmap getNonZero r in e (p `plus` q) r' === e p r' `plus` e q r'
   , testProperty "eval (p * q) r = eval p r * eval q r" $
-    \(ShortPoly p) (ShortPoly q) r -> e (p `times` q) r === e p r `times` e q r
+    \(ShortPoly p) (ShortPoly q) r -> let r' = fmap getNonZero r in e (p `times` q) r' === e p r' `times` e q r'
   , testProperty "eval x p = p" $
     \p -> e X (SV.fromTuple (p, undefined, undefined)) === p
   , testProperty "eval (monomial 0 c) p = c" $

--- a/test/Orthogonal.hs
+++ b/test/Orthogonal.hs
@@ -44,8 +44,8 @@ testSuite = testGroup "Orthogonal"
     ]
   ]
 
-prop_jacobi_de :: Rational -> Rational -> Property
-prop_jacobi_de a b = foldl' (.&&.) (property True) $
+prop_jacobi_de :: NonNegative Rational -> NonNegative Rational -> Property
+prop_jacobi_de (NonNegative a) (NonNegative b) = foldl' (.&&.) (property True) $
   zipWith (((=== 0) .) . de) [0..limit] (jacobi a b)
   where
     de :: Rational -> VPoly Rational -> VPoly Rational
@@ -104,8 +104,8 @@ prop_laguerreGen_de a  = foldl' (.&&.) (property True) $
     de :: Rational -> VPoly Rational -> VPoly Rational
     de n y = [0, 1] * deriv (deriv y) + [1 + a, -1] * deriv y + [n] * y
 
-prop_jacobi_norm :: Rational -> Rational -> Property
-prop_jacobi_norm a b = foldl' (.&&.) (property True) $
+prop_jacobi_norm :: NonNegative Rational -> NonNegative Rational -> Property
+prop_jacobi_norm (NonNegative a) (NonNegative b) = foldl' (.&&.) (property True) $
   zipWith (\n y -> norm n === eval y 1) [0..limit] (jacobi a b :: [VPoly Rational])
   where
     prod n x = product $ take n $ iterate (subtract 1) (fromIntegral n + x)

--- a/test/SparseLaurent.hs
+++ b/test/SparseLaurent.hs
@@ -142,14 +142,14 @@ evalTests = testGroup "eval" $ concat
 
 evalTestGroup
   :: forall v a.
-     (Eq a, Field a, Arbitrary a, Show a, G.Vector v (Word, a), G.Vector v (SU.Vector 1 Word, a), G.Vector v (Monom 1 a))
+     (Eq a, Field a, Num a, Arbitrary a, Show a, G.Vector v (Word, a), G.Vector v (SU.Vector 1 Word, a), G.Vector v (Monom 1 a))
   => Proxy (Laurent v a)
   -> [TestTree]
 evalTestGroup _ =
   [ testProperty "eval (p + q) r = eval p r + eval q r" $
-    \(ShortPoly p) (ShortPoly q) r -> e (p `plus` q) r === e p r `plus` e q r
+    \(ShortPoly p) (ShortPoly q) (NonZero r) -> e (p `plus` q) r === e p r `plus` e q r
   , testProperty "eval (p * q) r = eval p r * eval q r" $
-    \(ShortPoly p) (ShortPoly q) r -> e (p `times` q) r === e p r `times` e q r
+    \(ShortPoly p) (ShortPoly q) (NonZero r) -> e (p `times` q) r === e p r `times` e q r
   , testProperty "eval x p = p" $
     \p -> e X p === p
   , testProperty "eval (monomial 0 c) p = c" $


### PR DESCRIPTION
Fixes #64.

There were some cases where division by zero could occur. I believe the reason these cases weren't triggered before is that older `QuickCheck` versions had a worse `Arbitrary Rational` instance.