### PR TITLE
Fix `gegenbauer`

### DIFF
--- a/src/Data/Poly/Orthogonal.hs
+++ b/src/Data/Poly/Orthogonal.hs
@@ -59,9 +59,12 @@ legendreShifted = xs
 --
 -- @since 0.4.0.0
 gegenbauer :: (Eq a, Field a, Vector v a) => a -> [Poly v a]
-gegenbauer g = jacobi a a
+gegenbauer a = xs
   where
-    a = g - 1 `quot` 2
+    xs = 1 : toPoly [0, 2 * a] : zipWith3 recur (iterate (+ 1) 1) xs (drop 1 xs)
+    recur n c0 c1 = scale 1 (2 * (n + a) `quot` f) c1 - scale 0 ((n + 2 * a - 1) `quot` f) c0
+      where
+        f = n + 1
 
 -- | <https://en.wikipedia.org/wiki/Jacobi_polynomials Jacobi polynomials>.
 --

--- a/test/Orthogonal.hs
+++ b/test/Orthogonal.hs
@@ -38,6 +38,10 @@ testSuite = testGroup "Orthogonal"
     [ testProperty "hermiteProb" prop_hermiteProb
     , testProperty "hermitePhys" prop_hermitePhys
     ]
+  , testGroup "special cases"
+    [ testProperty "gegenbauer (1/2) = legendre" prop_gegenbauer_legendre
+    , testProperty "gegenbauer 1 = chebyshev2"   prop_gegenbauer_chebyshev
+    ]
   ]
 
 prop_jacobi_de :: Rational -> Rational -> Property
@@ -112,7 +116,7 @@ prop_gegenbauer_norm a = foldl' (.&&.) (property True) $
   zipWith (\n y -> norm n === eval y 1) [0..limit] (gegenbauer a :: [VPoly Rational])
   where
     prod n x = product $ take n $ iterate (subtract 1) (fromIntegral n + x)
-    norm n = prod n (a - 1 / 2) / prod n 0
+    norm n = prod n (2 * a - 1) / prod n 0
 
 prop_legendre_norm :: Property
 prop_legendre_norm = once $ foldl' (.&&.) (property True) $
@@ -146,6 +150,14 @@ prop_hermiteProb = once $ foldl' (.&&.) (property True) $
 prop_hermitePhys :: Property
 prop_hermitePhys = once $ foldl' (.&&.) (property True) $
   take limit $ zipWith (===) hermitePhys hermitePhysRef
+
+prop_gegenbauer_legendre :: Property
+prop_gegenbauer_legendre = once $ foldl' (.&&.) (property True) $
+  take limit $ zipWith (===) (gegenbauer (1/2)) (legendre :: [VPoly Rational])
+
+prop_gegenbauer_chebyshev :: Property
+prop_gegenbauer_chebyshev = once $ foldl' (.&&.) (property True) $
+  take limit $ zipWith (===) (gegenbauer 1) (chebyshev2 :: [VPoly Rational])
 
 integral11 :: VPoly Rational -> Rational
 integral11 x = eval y 1 - eval y (-1)


### PR DESCRIPTION
Closes #68.

Fix the `gegenbauer` polynomials, which were missing a factor. The new definition uses the recurrence relation from [Wikipedia](https://en.wikipedia.org/wiki/Gegenbauer_polynomials#Characterizations), which works for any `a`. This fixes the `gegenbauer` failures in #64. Also add tests for special cases of Gegenbauer polynomials.